### PR TITLE
Feature/no restricted globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,21 +19,21 @@ module.exports = {
     'keyword-spacing': ['error', {}],
     'max-params': ['error', 3],
     'no-constant-condition': 'off',
+    'no-empty': ['error', { allowEmptyCatch: true }],
     'one-var': ['error', 'never'],
     'quotes': ['error', 'single', {
       'allowTemplateLiterals': true,
       'avoidEscape': true,
     }],
+    'require-await': 'error',
+    'semi': 'error',
     'spaced-comment': ['error', 'always', {
       'block': {
         'balanced': true,
         'exceptions': ['*'],
       },
     }],
-    'template-curly-spacing': ['error', 'never'],
-    'semi': 'error',
-    'no-empty': ['error', { allowEmptyCatch: true }],
-    'require-await': 'error',
     'strict': 'error',
+    'template-curly-spacing': ['error', 'never'],
   },
 };

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'max-params': ['error', 3],
     'no-constant-condition': 'off',
     'no-empty': ['error', { allowEmptyCatch: true }],
+    'no-restricted-globals': ['error', 'event'],
     'one-var': ['error', 'never'],
     'quotes': ['error', 'single', {
       'allowTemplateLiterals': true,


### PR DESCRIPTION
fix: error on use of global `window.event` property

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/event)
use of this property is not recommended in new code:

> You *should* avoid using this property in new code, and should instead
> use the `Event` passed into the event handler function. This property
> is not universally supported and even when supported introduces
> potential fragility to your code.

I just came across a usage of it which was I believe unintended (we
forgot to name the parameter which was being passed to the event
handling function) and I think we should enable this rule to clean up
other instances...