### PR TITLE
fix: remove `strict`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ module.exports = {
         'exceptions': ['*'],
       },
     }],
-    'strict': 'error',
     'template-curly-spacing': ['error', 'never'],
   },
 };


### PR DESCRIPTION
This rule is already in eslint-config-crowdstrike-node, and was incorrectly placed here.