### PR TITLE
feat: bump ecmaVersion to 2022

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
   },
   env: {
     es6: true,


### PR DESCRIPTION
This should bring us in line with node 14 features (`await import()`).