### PR TITLE
feat: use newest beta of eslint-config-crowdstrike-node, drop self-de…

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": ">=8.57.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "devDependencies": {
     "@crowdstrike/commitlint": "^8.0.0",
     "eslint": "^9.0.0",
-    "eslint-config-crowdstrike": "10.1.0",
-    "eslint-config-crowdstrike-node": "4.0.0-beta.1",
+    "eslint-config-crowdstrike-node": "4.0.0-beta.2",
     "remark-cli": "^12.0.0",
     "remark-preset-lint-crowdstrike": "^4.0.0",
     "renovate-config-standard": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
   "devDependencies": {
     "@crowdstrike/commitlint": "^8.0.0",
     "eslint": "^9.0.0",
-    "eslint-config-crowdstrike-node": "4.0.0-beta.2",
+    "eslint-config-crowdstrike-node": "4.0.0-beta.2 || ^4.0.0",
     "remark-cli": "^12.0.0",
     "remark-preset-lint-crowdstrike": "^4.0.0",
     "renovate-config-standard": "^2.0.0",
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=8.57.0"
+    "eslint": "^8.57.0 || ^9.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,7 +1271,7 @@ eslint-compat-utils@^0.5.1:
   dependencies:
     semver "^7.5.4"
 
-eslint-config-crowdstrike-node@4.0.0-beta.2:
+"eslint-config-crowdstrike-node@4.0.0-beta.2 || ^4.0.0":
   version "4.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike-node/-/eslint-config-crowdstrike-node-4.0.0-beta.2.tgz#7791696d2133fff819051aaae5a84189699f0201"
   integrity sha512-DPEwVYsuUy50wQxmIvUvEJ0Gl/L3GQpXPeZ/nGkaoue9RKZthXGyk3pTciwLG043goTQh9jnkgQvGkiL7HlJEg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,7 +254,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.8.0", "@eslint/js@^9.0.0", "@eslint/js@^9.8.0":
+"@eslint/js@9.8.0", "@eslint/js@^9.0.0":
   version "9.8.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.8.0.tgz#ae9bc14bb839713c5056f5018bcefa955556d3a4"
   integrity sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==
@@ -1271,21 +1271,22 @@ eslint-compat-utils@^0.5.1:
   dependencies:
     semver "^7.5.4"
 
-eslint-config-crowdstrike-node@4.0.0-beta.1:
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike-node/-/eslint-config-crowdstrike-node-4.0.0-beta.1.tgz#fcc7d20c518c32bd0077c5ec4be50c09483380d5"
-  integrity sha512-yfhKY9qLOXkL6B4v0gvoDcF5IMxrfLqQnRfNoCrLTgX46UJ9gP86UYWgIxDMiDytlQdSpEfUvGGLh2GaYX+Y+Q==
+eslint-config-crowdstrike-node@4.0.0-beta.2:
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike-node/-/eslint-config-crowdstrike-node-4.0.0-beta.2.tgz#7791696d2133fff819051aaae5a84189699f0201"
+  integrity sha512-DPEwVYsuUy50wQxmIvUvEJ0Gl/L3GQpXPeZ/nGkaoue9RKZthXGyk3pTciwLG043goTQh9jnkgQvGkiL7HlJEg==
   dependencies:
-    "@eslint/eslintrc" "^3.1.0"
-    "@eslint/js" "^9.8.0"
+    eslint-config-crowdstrike "11.0.0-beta.0"
     eslint-plugin-json-files "^4.3.0"
     eslint-plugin-n "^17.0.0"
     globals "^15.8.0"
 
-eslint-config-crowdstrike@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike/-/eslint-config-crowdstrike-10.1.0.tgz#f46fd56e4ec9b4f89d27be608aea049530db164e"
-  integrity sha512-Wy4HdaVBfe5ItXI71Szv2viO7yvX8ZMeG1TblxYy84eAYi9S2p5fMzlwU1JJUlocu7cKBS697+KWYUM8+zk6oQ==
+eslint-config-crowdstrike@11.0.0-beta.0:
+  version "11.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-crowdstrike/-/eslint-config-crowdstrike-11.0.0-beta.0.tgz#8e795d13555f4bb374e093e3bed3cc617fd13507"
+  integrity sha512-OiDvVG5wIr+ToCMlYsYdJDwMODSapsqvJ7uQ0KWeVD7cfcvibK/4SIqWAnP5BpLrNG75/QPlo4171RS5L5bepg==
+  dependencies:
+    "@eslint/js" "^9.0.0"
 
 eslint-plugin-es-x@^7.5.0:
   version "7.8.0"


### PR DESCRIPTION
…pendency

Newest beta of `eslint-config-crowdstrike-node` bundles `eslint-config-crowdstrike@11.0.0-beta.0` so we can remove self-dependency.

Should be ready to go full release to `11.0.0` with this version