### PR TITLE
fix: remove unneeded cjs prescriptive sourceType

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports = [
     languageOptions: {
       globals: {},
       ecmaVersion: 2022,
-      sourceType: 'commonjs',
     },
 
     rules: {


### PR DESCRIPTION
The migration tool added this line, i overlooked ever taking it out. We want this package to be used in both module and commonjs packages